### PR TITLE
Fix symbol group tooltips update

### DIFF
--- a/js/kartograph.js
+++ b/js/kartograph.js
@@ -4804,7 +4804,7 @@
 
     SymbolGroup.prototype.tooltips = function(cb) {
       me = this;
-      me.tooltips = cb;
+      me.tooltip = cb;
       me._initTooltips();
       return me;
     };


### PR DESCRIPTION
Symbol group tooltips cannot be updated with `symbolGroup.tooltips(callback);` at the moment.
